### PR TITLE
Change logger level to debug when logging inbound messages

### DIFF
--- a/phx_events/client.py
+++ b/phx_events/client.py
@@ -234,7 +234,7 @@ class PHXChannelsClient:
 
         async for socket_message in websocket:
             phx_message = self._parse_message(socket_message)
-            self.logger.info(f'Processing message - {phx_message=}')
+            self.logger.debug(f'Processing message - {phx_message=}')
             event = phx_message.event
 
             if event == PHXEvent.close:
@@ -257,7 +257,7 @@ class PHXChannelsClient:
                 self.logger.debug(f'Ignoring {phx_message=} - no event handlers registered')
                 continue
 
-            self.logger.info(f'Submitting message to {event=} queue - {phx_message=}')
+            self.logger.debug(f'Submitting message to {event=} queue - {phx_message=}')
             await event_handler_config.queue.put(phx_message)
 
     async def _subscribe_to_registered_topics(self, websocket: client.WebSocketClientProtocol) -> None:


### PR DESCRIPTION
Hi @AceFire6 

The client log level was set to info for each message, this gets spammy at scale real fast. I have changed this to debug. This should also [close](https://github.com/AceFire6/phx_events/issues/62) 